### PR TITLE
fix Absolute existence filter test

### DIFF
--- a/src/parsers/filter_selector.ts
+++ b/src/parsers/filter_selector.ts
@@ -198,7 +198,7 @@ const applyQuery = (
 			return applyCurrentNode(query, rootNode, [json]).length > 0;
 		}
 		case "Root": {
-			return applyRoot(query, json).length > 0;
+			return applyRoot(query, rootNode).length > 0;
 		}
 	}
 


### PR DESCRIPTION
fix #7

Root exp should be given root node.

## Test Case

```json
{
  "name": "filter, absolute existence, with segments",
  "selector": "$[?$.*.a]",
  "document": [
    {
      "a": "b",
      "d": "e"
    },
    {
      "b": "c",
      "d": "f"
    }
  ],
  "result": [
    {
      "a": "b",
      "d": "e"
    },
    {
      "b": "c",
      "d": "f"
    }
  ],
  "result_paths": [
    "$[0]",
    "$[1]"
  ]
},
```

## Actual

```diff
- Expected
+ Received

- Array [
-   Object {
-     "a": "b",
-     "d": "e",
-   },
-   Object {
-     "b": "c",
-     "d": "f",
-   },
- ]
+ Array []
```