### PR TITLE
Normalized path

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 [![NPM Version](https://img.shields.io/npm/v/jsonpath-js)](https://www.npmjs.com/package/jsonpath-js)
 [![Link Checker](https://github.com/ashphy/jsonpath-js/actions/workflows/lint.yml/badge.svg)](https://github.com/ashphy/jsonpath-js/actions/workflows/lint.yml)
 
+> [!WARNING]
+> Urgent info that needs immediate user attention to avoid problems.
+
 An implementation of RFC 9535 [JSONPath](http://goessner.net/articles/JsonPath/)
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ const result = query.find({
 
 // [ 'John Doe', 'Jane Doe' ]
 console.log(result);
+
+
+const pathResult = query.paths({
+	users: [{ name: "John Doe" }, { name: "Jane Doe" }],
+});
+
+// [
+// 	{ value: "John Doe", path: "$['users'][0]['name']" },
+// 	{ value: "Jane Doe", path: "$['users'][1]['name']" },
+// ];
+console.log(pathResult);
 ```
 
 ## Contributing

--- a/src/comparator/NodeComparator.ts
+++ b/src/comparator/NodeComparator.ts
@@ -1,3 +1,4 @@
+import type { Json } from "../types/json";
 import type { Node } from "../types/node";
 import { Nothing } from "../types/nothing";
 import type { ComparisonOperators } from "./ComparisonOperators";
@@ -6,7 +7,7 @@ import type { ComparisonOperators } from "./ComparisonOperators";
 // - A comparison using the operator == yields true if and only the other side also results
 //   in an empty nodelist or the special result Nothing.
 // - A comparison using the operator < yields false.
-export const NodeComparator: ComparisonOperators<Node | Nothing> = {
+export const NodeComparator: ComparisonOperators<Json | Nothing> = {
 	"=="(a, b) {
 		return (a === Nothing || b === Nothing) && a === b;
 	},

--- a/src/functions/function_definitions.ts
+++ b/src/functions/function_definitions.ts
@@ -1,6 +1,6 @@
 import { FunctionType } from "../functions/function_types";
-import type { JsonValue } from "../types/json";
-import type { Node, NodeList } from "../types/node";
+import type { Json, JsonValue } from "../types/json";
+import { type Node, type NodeList, isNode, isNodeList } from "../types/node";
 import { Nothing } from "../types/nothing";
 import { isJsonPrimitive } from "../utils";
 
@@ -19,9 +19,10 @@ export const ValueTypeDef: FunctionTypeDef<FunctionType.ValueType> = {
 	convert: (arg) => {
 		if (arg === Nothing) return arg;
 		if (isJsonPrimitive(arg)) return arg;
-		if (Array.isArray(arg)) {
+		if (isNode(arg)) return arg.value;
+		if (isNodeList(arg)) {
 			if (arg.length === 0) return Nothing;
-			if (arg.length === 1) return arg[0];
+			if (arg.length === 1) return arg[0].value;
 		}
 
 		throw new Error(
@@ -33,7 +34,7 @@ export const ValueTypeDef: FunctionTypeDef<FunctionType.ValueType> = {
 export const NodesTypeDef: FunctionTypeDef<FunctionType.NodesType> = {
 	type: "NodesType",
 	convert: (arg) => {
-		if (Array.isArray(arg)) return arg;
+		if (isNodeList(arg)) return arg;
 
 		throw new Error(
 			`Invalid argument type "${JSON.stringify(arg)}" is not a NodesType`,
@@ -96,7 +97,7 @@ export const extractArgs = <
 	Return extends FunctionTypeDef<unknown>,
 >(
 	functionDefinition: FunctionDefinition<Args, Return>,
-	args: (Node | NodeList | Nothing)[],
+	args: (Json | Node | NodeList | Nothing)[],
 ) => {
 	const argDefs = functionDefinition.args;
 	if (args.length !== argDefs.length) {

--- a/src/functions/value.ts
+++ b/src/functions/value.ts
@@ -21,7 +21,7 @@ export const ValueFunction = createFunctionDefinition({
 		// Its only argument is an instance of NodesType (possibly taken from a filter-query, as in the example above). The result is an instance of ValueType.
 		// If the argument contains a single node, the result is the value of the node.
 		if (nodes.length === 1) {
-			return nodes[0];
+			return nodes[0].value;
 		}
 
 		// If the argument is the empty nodelist or contains multiple nodes, the result is Nothing.

--- a/src/jsonpath_js.ts
+++ b/src/jsonpath_js.ts
@@ -2,6 +2,11 @@ import { type JsonpathQuery, parse } from "./jsonpath";
 import { run } from "./parser";
 import type { Json } from "./types/json";
 
+type PathResult = {
+	value: Json;
+	path: string;
+};
+
 export class JSONPathJS {
 	rootNode: JsonpathQuery;
 
@@ -12,6 +17,20 @@ export class JSONPathJS {
 
 	find(json: Json): Json {
 		const resultNodeList = run(json, this.rootNode);
-		return resultNodeList.filter((json) => json !== undefined);
+		return resultNodeList
+			.filter((json) => json !== undefined)
+			.map((json) => json.value);
+	}
+
+	paths(json: Json): PathResult[] {
+		const resultNodeList = run(json, this.rootNode);
+		return resultNodeList
+			.filter((json) => json !== undefined)
+			.map((json) => {
+				return {
+					value: json.value,
+					path: json.path,
+				};
+			});
 	}
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,9 +1,9 @@
 import type { JsonpathQuery } from "./jsonpath";
 import { applyRoot } from "./parsers/root";
 import type { Json } from "./types/json";
-import type { Node, NodeList } from "./types/node";
+import { type Node, type NodeList, createNode } from "./types/node";
 
 export function run(json: Json, query: JsonpathQuery): NodeList {
-	const rootNode: Node = json;
+	const rootNode: Node = createNode(json, "$");
 	return applyRoot(query, rootNode);
 }

--- a/src/parsers/array_slice_selector.ts
+++ b/src/parsers/array_slice_selector.ts
@@ -1,6 +1,5 @@
 import type { SliceSelector } from "../jsonpath";
-import type { Json } from "../types/json";
-import type { NodeList } from "../types/node";
+import { type Node, type NodeList, addIndexPath } from "../types/node";
 
 // 2.3.4. Array Slice Selector
 // The array slice selector has the form <start>:<end>:<step>.
@@ -9,19 +8,20 @@ import type { NodeList } from "../types/node";
 // while incrementing by step with a default of 1.
 export function applySliceSelector(
 	selector: SliceSelector,
-	json: Json,
+	node: Node,
 ): NodeList {
-	if (!Array.isArray(json)) {
+	if (!Array.isArray(node.value)) {
 		// throw new Error(`JSON node ${JSON.stringify(json)} is not an array`);
 		return [];
 	}
 
 	const step = selector.step ?? 1;
-	const start = selector.start ?? (step >= 0 ? 0 : json.length - 1);
-	const end = selector.end ?? (step >= 0 ? json.length : -json.length - 1);
-	const array = [];
+	const start = selector.start ?? (step >= 0 ? 0 : node.value.length - 1);
+	const end =
+		selector.end ?? (step >= 0 ? node.value.length : -node.value.length - 1);
+	const array: NodeList = [];
 
-	const [lower, upper] = bounds(start, end, step, json.length);
+	const [lower, upper] = bounds(start, end, step, node.value.length);
 
 	// IF step > 0 THEN
 	//
@@ -42,11 +42,11 @@ export function applySliceSelector(
 	// END IF
 	if (step > 0) {
 		for (let i = lower; i < upper; i += step) {
-			array.push(json[i]);
+			array.push(addIndexPath(node, node.value[i], i));
 		}
 	} else if (step < 0) {
 		for (let i = upper; lower < i; i += step) {
-			array.push(json[i]);
+			array.push(addIndexPath(node, node.value[i], i));
 		}
 	}
 

--- a/src/parsers/filter_selector.ts
+++ b/src/parsers/filter_selector.ts
@@ -25,7 +25,7 @@ import type {
 import type { Node, NodeList } from "../types/node";
 import { Nothing } from "../types/nothing";
 import { isJsonArray, isJsonObject, isJsonPrimitive, toArray } from "../utils";
-import { enumarateNode } from "../utils/enumarateNode";
+import { enumerateNode } from "../utils/enumarateNode";
 import { applyFunction } from "./function_extentions";
 import { applyRoot, applySegments } from "./root";
 
@@ -47,7 +47,7 @@ export function applyFilterSelector(
 		return [];
 	}
 
-	return enumarateNode(currentNode).filter((node) => {
+	return enumerateNode(currentNode).filter((node) => {
 		return applyFilterExpression(selector.expr, rootNode, node);
 	});
 }

--- a/src/parsers/filter_selector.ts
+++ b/src/parsers/filter_selector.ts
@@ -36,18 +36,18 @@ import { applyRoot, applySegments } from "./root";
 export function applyFilterSelector(
 	selector: FilterSelector,
 	rootNode: Node,
-	currentNode: Node,
+	node: Node,
 ): NodeList {
 	// The filter selector works with arrays and objects exclusively.
 	// Its result is a list of(zero, one, multiple, or all)
 	// their array elements or member values, respectively.
 	// Applied to a primitive value,
 	// it selects nothing(and therefore does not contribute to the result of the filter selector).
-	if (isJsonPrimitive(currentNode.value)) {
+	if (isJsonPrimitive(node.value)) {
 		return [];
 	}
 
-	return enumerateNode(currentNode).filter((node) => {
+	return enumerateNode(node).filter((node) => {
 		return applyFilterExpression(selector.expr, rootNode, node);
 	});
 }
@@ -55,17 +55,17 @@ export function applyFilterSelector(
 const applyFilterExpression = (
 	expr: FilterExpression,
 	rootNode: Node,
-	currentNode: Node,
+	node: Node,
 ): boolean => {
 	const expType = expr.type;
 	switch (expType) {
 		case "ComparisonExpr":
-			return applyCompare(expr, rootNode, currentNode);
+			return applyCompare(expr, rootNode, node);
 		case "TestExpr":
-			return applyTest(expr, rootNode, currentNode);
+			return applyTest(expr, rootNode, node);
 		case "LogicalBinary":
 		case "LogicalUnary":
-			return applyLogical(expr, rootNode, currentNode);
+			return applyLogical(expr, rootNode, node);
 		default:
 			expType satisfies never;
 	}

--- a/src/parsers/function_extentions.ts
+++ b/src/parsers/function_extentions.ts
@@ -61,17 +61,17 @@ export const applyFunction = (
 const applyFunctionArgument = (
 	argument: FunctionArgument,
 	rootNode: Node,
-	json: Json,
-): Node | NodeList | Nothing => {
+	node: Node,
+): Json | Node | NodeList | Nothing => {
 	switch (argument.type) {
 		case "Literal":
 			return argument.member;
 		case "CurrentNode":
-			return applyCurrentNode(argument, rootNode, [json]);
+			return applyCurrentNode(argument, rootNode, [node]);
 		case "Root":
 			return applyRoot(argument, rootNode);
 		case "FunctionExpr":
-			return applyFunction(argument, rootNode, json);
+			return applyFunction(argument, rootNode, node);
 		default:
 			// TODO: remove default case
 			throw new Error(`Unknown argument type "${argument.type}"`);

--- a/src/parsers/root.ts
+++ b/src/parsers/root.ts
@@ -50,12 +50,12 @@ export function applySegments(
 export function applySegment(
 	segment: ChildSegement | DescendantSegment,
 	rootNode: Node,
-	currentNode: Node,
+	node: Node,
 ): NodeList {
 	if (Array.isArray(segment)) {
 		// ChildSegement
 		const selectorResults = segment.map((selector) => {
-			const selectorResult = applySelector(selector, rootNode, currentNode);
+			const selectorResult = applySelector(selector, rootNode, node);
 			return selectorResult;
 		});
 		const segementResult = selectorResults
@@ -64,7 +64,7 @@ export function applySegment(
 		return segementResult;
 	}
 	// DescendantSegment
-	const descendantNodes = traverseDescendant(currentNode);
+	const descendantNodes = traverseDescendant(node);
 	return descendantNodes.flatMap((node) => {
 		return segment.selectors.flatMap((selector) => {
 			return applySelector(selector, rootNode, node);
@@ -77,22 +77,22 @@ export function applySegment(
 function applySelector(
 	selector: Selector | MemberNameShorthand,
 	rootNode: Node,
-	currentNode: Node,
+	node: Node,
 ): NodeList {
 	const type = selector.type;
 	switch (type) {
 		case "WildcardSelector":
-			return applyWildcardSelector(selector, currentNode);
+			return applyWildcardSelector(selector, node);
 		case "IndexSelector":
-			return applyIndexSelector(selector, currentNode);
+			return applyIndexSelector(selector, node);
 		case "SliceSelector":
-			return applySliceSelector(selector, currentNode);
+			return applySliceSelector(selector, node);
 		case "MemberNameShorthand":
-			return applyMemberNameSelector(selector, currentNode);
+			return applyMemberNameSelector(selector, node);
 		case "NameSelector":
-			return applyMemberNameSelector(selector, currentNode);
+			return applyMemberNameSelector(selector, node);
 		case "FilterSelector":
-			return applyFilterSelector(selector, rootNode, currentNode);
+			return applyFilterSelector(selector, rootNode, node);
 		default:
 			return type satisfies never;
 	}

--- a/src/parsers/root.ts
+++ b/src/parsers/root.ts
@@ -109,7 +109,6 @@ function applyWildcardSelector(
 
 	if (Array.isArray(json)) {
 		for (const a in json) {
-			// TODO: ここfor ofじゃね？
 			if (Object.prototype.hasOwnProperty.call(node.value, a)) {
 				// Note that the children of an object are its member values, not its member names.
 				// results.push({ json: json[a], path: `${node.path}[${a}]` });

--- a/src/types/node.ts
+++ b/src/types/node.ts
@@ -1,4 +1,35 @@
+import { escapeMemberName } from "../utils/escapeMemberName";
 import type { Json } from "./json";
 
-export type Node = Json;
+const nodeType: unique symbol = Symbol("NodeType");
+
+export type Node = { [nodeType]: unknown; value: Json; path: string };
 export type NodeList = Node[];
+
+export function createNode(json: Json, path: string): Node {
+	return { [nodeType]: undefined, value: json, path };
+}
+
+export function addMemberPath(
+	base: Node,
+	newValue: Json,
+	memberName: string,
+): Node {
+	return createNode(
+		newValue,
+		`${base.path}['${escapeMemberName(memberName)}']`,
+	);
+}
+
+export function addIndexPath(base: Node, newValue: Json, index: number): Node {
+	return createNode(newValue, `${base.path}[${index}]`);
+}
+
+export function isNode(node: unknown): node is Node {
+	return typeof node === "object" && node !== null && nodeType in node;
+}
+
+export function isNodeList(obj: unknown): obj is NodeList {
+	if (!Array.isArray(obj)) return false;
+	return obj.every(isNode);
+}

--- a/src/utils/enumarateNode.ts
+++ b/src/utils/enumarateNode.ts
@@ -6,7 +6,7 @@ import {
 } from "../types/node";
 import { isJsonArray, isJsonObject, isJsonPrimitive } from "../utils";
 
-export function enumarateNode(node: Node): NodeList {
+export function enumerateNode(node: Node): NodeList {
 	const { value: json, path } = node;
 	if (isJsonPrimitive(json)) {
 		return [];

--- a/src/utils/enumarateNode.ts
+++ b/src/utils/enumarateNode.ts
@@ -1,0 +1,26 @@
+import {
+	type Node,
+	type NodeList,
+	addIndexPath,
+	addMemberPath,
+} from "../types/node";
+import { isJsonArray, isJsonObject, isJsonPrimitive } from "../utils";
+
+export function enumarateNode(node: Node): NodeList {
+	const { value: json, path } = node;
+	if (isJsonPrimitive(json)) {
+		return [];
+	}
+	if (isJsonArray(json)) {
+		return json.map((item, index) => {
+			return addIndexPath(node, item, index);
+		});
+	}
+	if (isJsonObject(json)) {
+		return Object.entries(json).map(([key, value]) => {
+			return addMemberPath(node, value, key);
+			// return { json: value, path: `${path}['${escapeMemberName(key)}']` };
+		});
+	}
+	return [];
+}

--- a/src/utils/enumarateNode.ts
+++ b/src/utils/enumarateNode.ts
@@ -19,7 +19,6 @@ export function enumerateNode(node: Node): NodeList {
 	if (isJsonObject(json)) {
 		return Object.entries(json).map(([key, value]) => {
 			return addMemberPath(node, value, key);
-			// return { json: value, path: `${path}['${escapeMemberName(key)}']` };
 		});
 	}
 	return [];

--- a/src/utils/escapeMemberName.ts
+++ b/src/utils/escapeMemberName.ts
@@ -5,9 +5,7 @@
  * @returns
  */
 export const escapeMemberName = (name: string): string => {
-	// eslint-disable-next-line no-control-regex
-	// TODO: Add explanation
-	// biome-ignore lint/suspicious/noControlCharactersInRegex: <explanation>
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: This regex is used to escape control characters
 	return name.replace(/['\\\b\f\n\r\t\u0000-\u001F]/g, (char) => {
 		switch (char) {
 			case "'":

--- a/src/utils/escapeMemberName.ts
+++ b/src/utils/escapeMemberName.ts
@@ -1,5 +1,5 @@
 /**
- * Escape a member name for nomalized path
+ * Escape a member name for normalized path
  * See: https://www.rfc-editor.org/rfc/rfc9535.html#section-2.7
  * @param name
  * @returns

--- a/src/utils/escapeMemberName.ts
+++ b/src/utils/escapeMemberName.ts
@@ -1,0 +1,31 @@
+/**
+ * Escape a member name for nomalized path
+ * See: https://www.rfc-editor.org/rfc/rfc9535.html#section-2.7
+ * @param name
+ * @returns
+ */
+export const escapeMemberName = (name: string): string => {
+	// eslint-disable-next-line no-control-regex
+	// TODO: Add explanation
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: <explanation>
+	return name.replace(/['\\\b\f\n\r\t\u0000-\u001F]/g, (char) => {
+		switch (char) {
+			case "'":
+				return "\\'";
+			case "\\":
+				return "\\\\";
+			case "\b":
+				return "\\b";
+			case "\f":
+				return "\\f";
+			case "\n":
+				return "\\n";
+			case "\r":
+				return "\\r";
+			case "\t":
+				return "\\t";
+			default:
+				return `\\u${char.charCodeAt(0).toString(16).padStart(4, "0")}`;
+		}
+	});
+};

--- a/src/utils/traverseDescendant.ts
+++ b/src/utils/traverseDescendant.ts
@@ -1,11 +1,11 @@
 import type { Node, NodeList } from "../types/node";
-import { enumarateNode } from "./enumarateNode";
+import { enumerateNode } from "./enumarateNode";
 
 export const traverseDescendant = (node: Node): NodeList => {
 	const nodelist: NodeList = [];
 	nodelist.push(node);
 
-	for (const child of enumarateNode(node)) {
+	for (const child of enumerateNode(node)) {
 		nodelist.push(...traverseDescendant(child));
 	}
 

--- a/src/utils/traverseDescendant.ts
+++ b/src/utils/traverseDescendant.ts
@@ -1,21 +1,12 @@
-import type { Json } from "../types/json";
-import type { NodeList } from "../types/node";
-import { isJsonObject } from "../utils";
+import type { Node, NodeList } from "../types/node";
+import { enumarateNode } from "./enumarateNode";
 
-export const traverseDescendant = (json: Json) => {
+export const traverseDescendant = (node: Node): NodeList => {
 	const nodelist: NodeList = [];
-	nodelist.push(json);
+	nodelist.push(node);
 
-	if (Array.isArray(json)) {
-		for (const node of json) {
-			nodelist.push(...traverseDescendant(node));
-		}
-	} else if (isJsonObject(json)) {
-		for (const key in json) {
-			if (Object.prototype.hasOwnProperty.call(json, key)) {
-				nodelist.push(...traverseDescendant(json[key]));
-			}
-		}
+	for (const child of enumarateNode(node)) {
+		nodelist.push(...traverseDescendant(child));
 	}
 
 	return nodelist;

--- a/tests/RFC9535/ietf_jsonpath.test.ts
+++ b/tests/RFC9535/ietf_jsonpath.test.ts
@@ -75,7 +75,7 @@ describe("RFC 9535 JSONPath: Query Expressions for JSON", () => {
 			});
 
 			it("Non-deterministic ordering", () => {
-				testJSONPathIgnoreingArrayOrder({
+				testJSONPath({
 					json: json,
 					jsonpath: "$.o[*, *]",
 					expected: [1, 2, 1, 2],

--- a/tests/RFC9535/jsonpath-compliance-test-suite.test.ts
+++ b/tests/RFC9535/jsonpath-compliance-test-suite.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { testJSONPath } from "../utils";
+import { testJSONPath, testNormalizedPath } from "../utils";
 
 import { JSONPathJS } from "../../src/jsonpath_js";
 import type { JsonValue } from "../../src/types/json";
@@ -25,6 +25,16 @@ describe("JSONPath Compliance Test Suite", () => {
 					expected: testCase.result ?? (testCase.results?.[0] as JsonValue),
 				});
 			});
+
+			if (testCase.result_paths) {
+				test(`${testCase.name} Normalized Path`, () => {
+					testNormalizedPath({
+						json: testCase.document as JsonValue,
+						jsonpath: testCase.selector,
+						expected: testCase.result_paths,
+					});
+				});
+			}
 		}
 	}
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -68,7 +68,11 @@ describe("Stefan Goessner JsonPath implementation", () => {
 	});
 
 	it("subscript operator", () => {
-		testJSONPath({ json: json, jsonpath: "$..book[2]", expected: [book3] });
+		testJSONPath({
+			json: json,
+			jsonpath: "$..book[2]",
+			expected: [book3],
+		});
 	});
 
 	it("array slice operator borrowed from ES4", () => {

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -28,3 +28,17 @@ export function testJSONPathIgnoreingArrayOrder({
 	const result = path.find(json);
 	expect(result).toEqual(expect.arrayContaining(expected));
 }
+
+export function testNormalizedPath({
+	json,
+	jsonpath,
+	expected,
+}: {
+	json: Json;
+	jsonpath: string;
+	expected: string[];
+}) {
+	const path = new JSONPathJS(jsonpath);
+	const paths = path.paths(json).map((path) => path.path);
+	expect(paths).toStrictEqual(expected);
+}

--- a/tests/utils/traverseDescendant.test.ts
+++ b/tests/utils/traverseDescendant.test.ts
@@ -1,15 +1,16 @@
 import { describe, expect, test } from "vitest";
+import { createNode } from "../../src/types/node";
 import { traverseDescendant } from "../../src/utils/traverseDescendant";
 
 describe("traverseDescendant", () => {
 	test("empty object traverses empty", () => {
-		const json = {};
-		expect(traverseDescendant(json)).toEqual([{}]);
+		const node = createNode({}, "");
+		expect(traverseDescendant(node).map((item) => item.value)).toEqual([{}]);
 	});
 
 	test("empty object traverses empty", () => {
-		const json = [[[1]], [2]];
-		expect(traverseDescendant(json)).toEqual([
+		const node = createNode([[[1]], [2]], "");
+		expect(traverseDescendant(node).map((item) => item.value)).toEqual([
 			[[[1]], [2]],
 			[[1]],
 			[1],


### PR DESCRIPTION
Close #6 

Added a feature to retrieve the normalized path defined at RFC9535 2.7

### Usage

Add a `path` function 

```ts
import { JSONPathJS } from "jsonpath-js";

const query = new JSONPathJS("$.users[*].name");
const result = query.paths({
	users: [{ name: "John Doe" }, { name: "Jane Doe" }],
});

// [
// 	{ value: "John Doe", path: "$['users'][0]['name']" },
// 	{ value: "Jane Doe", path: "$['users'][1]['name']" },
// ];
console.log(result);

```