### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 name: "Lint and Test"
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ashphy/jsonpath-js/security/code-scanning/7](https://github.com/ashphy/jsonpath-js/security/code-scanning/7)

To fix the issue, we need to add a `permissions` block to the root of the workflow file. This block will define the least privileges required for the workflow. Since none of the jobs in the workflow require write access to the repository, we can set `contents: read` as the minimal permission. This change will apply to all jobs in the workflow unless overridden by a job-specific `permissions` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
