### PR TITLE
Upgrade Biome to v2.0.0

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.0.4/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",
@@ -7,27 +7,38 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"ignore": [
-			"src/jsonpath.ts",
-			"src/grammar/jsonpath_js.js",
-			"src/grammar/jsonpath_js.d.ts",
-			"tests/RFC9535/jsonpath-compliance-test-suite/*"
+		"includes": [
+			"**",
+			"!**/src/jsonpath.ts",
+			"!**/src/grammar/jsonpath_js.js",
+			"!**/src/grammar/jsonpath_js.d.ts",
+			"!**/tests/RFC9535/jsonpath-compliance-test-suite/**/*"
 		]
 	},
 	"formatter": {
 		"enabled": true,
 		"indentStyle": "tab",
-		"ignore": ["**/package.json"]
+		"includes": ["**", "!**/package.json"]
 	},
-	"organizeImports": {
-		"enabled": true
-	},
+	"assist": { "actions": { "source": { "organizeImports": "on" } } },
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true
+			"recommended": true,
+			"style": {
+				"noParameterAssign": "error",
+				"useAsConstAssertion": "error",
+				"useDefaultParameterLast": "error",
+				"useEnumInitializers": "error",
+				"useSelfClosingElements": "error",
+				"useSingleVarDeclarator": "error",
+				"noUnusedTemplateLiteral": "error",
+				"useNumberNamespace": "error",
+				"noInferrableTypes": "error",
+				"noUselessElse": "error"
+			}
 		},
-		"ignore": ["package.json"]
+		"includes": ["**", "!**/package.json"]
 	},
 	"javascript": {
 		"formatter": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.2.0",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "2.0.0",
+				"@biomejs/biome": "2.0.4",
 				"@types/jest": "^29.5.8",
 				"@types/node": "^18.7.3",
 				"npm-run-all": "^4.1.5",
@@ -132,9 +132,9 @@
 			}
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.0.0.tgz",
-			"integrity": "sha512-BlUoXEOI/UQTDEj/pVfnkMo8SrZw3oOWBDrXYFT43V7HTkIUDkBRY53IC5Jx1QkZbaB+0ai1wJIfYwp9+qaJTQ==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.0.4.tgz",
+			"integrity": "sha512-DNA++xe+E7UugTvI/HhzSFl6OwrVgU8SIV0Mb2fPtWPk2/oTr4eOSA5xy1JECrvgJeYxurmUBOS49qxv/OUkrQ==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
@@ -148,20 +148,20 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.0.0",
-				"@biomejs/cli-darwin-x64": "2.0.0",
-				"@biomejs/cli-linux-arm64": "2.0.0",
-				"@biomejs/cli-linux-arm64-musl": "2.0.0",
-				"@biomejs/cli-linux-x64": "2.0.0",
-				"@biomejs/cli-linux-x64-musl": "2.0.0",
-				"@biomejs/cli-win32-arm64": "2.0.0",
-				"@biomejs/cli-win32-x64": "2.0.0"
+				"@biomejs/cli-darwin-arm64": "2.0.4",
+				"@biomejs/cli-darwin-x64": "2.0.4",
+				"@biomejs/cli-linux-arm64": "2.0.4",
+				"@biomejs/cli-linux-arm64-musl": "2.0.4",
+				"@biomejs/cli-linux-x64": "2.0.4",
+				"@biomejs/cli-linux-x64-musl": "2.0.4",
+				"@biomejs/cli-win32-arm64": "2.0.4",
+				"@biomejs/cli-win32-x64": "2.0.4"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.0.0.tgz",
-			"integrity": "sha512-QvqWYtFFhhxdf8jMAdJzXW+Frc7X8XsnHQLY+TBM1fnT1TfeV/v9vsFI5L2J7GH6qN1+QEEJ19jHibCY2Ypplw==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.0.4.tgz",
+			"integrity": "sha512-r5McIUMMiedwJ2rltuXhj0+w0W7IJLpkOS+OGCVZQQOOcrGY9gUSUmOo7O6Z7P0vlv5YYZkPbi+qR9MDDWRBSw==",
 			"cpu": [
 				"arm64"
 			],
@@ -176,9 +176,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.0.0.tgz",
-			"integrity": "sha512-5JFhls1EfmuIH4QGFPlNpxJQFC6ic3X1ltcoLN+eSRRIPr6H/lUS1ttuD0Fj7rPgPhZqopK/jfH8UVj/1hIsQw==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.0.4.tgz",
+			"integrity": "sha512-aV5Zc/3E3aXFbrjK1IgCMEQc+6PCkBL+NS+vtjoNM2VPFeM5OL5Q82BI4YZyPnebj+k42BPIoYtz0jJ95PGRRg==",
 			"cpu": [
 				"x64"
 			],
@@ -193,9 +193,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.0.0.tgz",
-			"integrity": "sha512-BAH4QVi06TzAbVchXdJPsL0Z/P87jOfes15rI+p3EX9/EGTfIjaQ9lBVlHunxcmoptaA5y1Hdb9UYojIhmnjIw==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.0.4.tgz",
+			"integrity": "sha512-nlJhf7DyuajMj+S7Ygum59cbrHvI/nSRvedfJcEIx4X7SsiZjpRUiC5XtEn77kg7NIKq/KqG5roQIHkmjuFHCw==",
 			"cpu": [
 				"arm64"
 			],
@@ -210,9 +210,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.0.0.tgz",
-			"integrity": "sha512-Bxsz8ki8+b3PytMnS5SgrGV+mbAWwIxI3ydChb/d1rURlJTMdxTTq5LTebUnlsUWAX6OvJuFeiVq9Gjn1YbCyA==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.0.4.tgz",
+			"integrity": "sha512-cNukq2PthoOa7quqaKoEFz4Zd1pDPJGfTR5jVyk9Z9iFHEm6TI7+7eeIs3aYcEuuJPNFR9xhJ4Uj3E2iUWkV3A==",
 			"cpu": [
 				"arm64"
 			],
@@ -227,9 +227,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.0.0.tgz",
-			"integrity": "sha512-09PcOGYTtkopWRm6mZ/B6Mr6UHdkniUgIG/jLBv+2J8Z61ezRE+xQmpi3yNgUrFIAU4lPA9atg7mhvE/5Bo7Wg==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.0.4.tgz",
+			"integrity": "sha512-jlzrNZ+OzN9wvp2RL3cl5Y4NiV7xSU+QV5A8bWXke1on3jKy7QbXajybSjVQ6aFw1gdrqkO/W8xV5HODhIMT4g==",
 			"cpu": [
 				"x64"
 			],
@@ -244,9 +244,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.0.0.tgz",
-			"integrity": "sha512-tiQ0ABxMJb9I6GlfNp0ulrTiQSFacJRJO8245FFwE3ty3bfsfxlU/miblzDIi+qNrgGsLq5wIZcVYGp4c+HXZA==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.0.4.tgz",
+			"integrity": "sha512-oWQALSbp8xF0t/wiHU2zdkZOpIHyaI9QxQv0Ytty9GAKsCGP6pczp8qyKD/P49iGJdDozHp5KiuQPxs33APhyA==",
 			"cpu": [
 				"x64"
 			],
@@ -261,9 +261,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.0.0.tgz",
-			"integrity": "sha512-vrTtuGu91xNTEQ5ZcMJBZuDlqr32DWU1r14UfePIGndF//s2WUAmer4FmgoPgruo76rprk37e8S2A2c0psXdxw==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.0.4.tgz",
+			"integrity": "sha512-/PbNhMJo9ONja7hOxLlifM/qgeHpRD9bF2flTz5KIrXnQqpuegaRuwP/HYdJ9TFkTKFjHkPLoE4onOz3HIT5CQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -278,9 +278,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.0.0.tgz",
-			"integrity": "sha512-2USVQ0hklNsph/KIR72ZdeptyXNnQ3JdzPn3NbjI4Sna34CnxeiYAaZcZzXPDl5PYNFBivV4xmvT3Z3rTmyDBg==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.0.4.tgz",
+			"integrity": "sha512-dIM4SgO4/Rmsb4X7fwKtciQ682SZDSC1lm42uSM9gt8zNqBIeTaqsMc6eO1DpxYWMlAb/n2SML9+HUHmCib7NA==",
 			"cpu": [
 				"x64"
 			],

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.2.0",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "1.9.4",
+				"@biomejs/biome": "2.0.0",
 				"@types/jest": "^29.5.8",
 				"@types/node": "^18.7.3",
 				"npm-run-all": "^4.1.5",
@@ -132,11 +132,10 @@
 			}
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
-			"integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.0.0.tgz",
+			"integrity": "sha512-BlUoXEOI/UQTDEj/pVfnkMo8SrZw3oOWBDrXYFT43V7HTkIUDkBRY53IC5Jx1QkZbaB+0ai1wJIfYwp9+qaJTQ==",
 			"dev": true,
-			"hasInstallScript": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
 				"biome": "bin/biome"
@@ -149,20 +148,20 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "1.9.4",
-				"@biomejs/cli-darwin-x64": "1.9.4",
-				"@biomejs/cli-linux-arm64": "1.9.4",
-				"@biomejs/cli-linux-arm64-musl": "1.9.4",
-				"@biomejs/cli-linux-x64": "1.9.4",
-				"@biomejs/cli-linux-x64-musl": "1.9.4",
-				"@biomejs/cli-win32-arm64": "1.9.4",
-				"@biomejs/cli-win32-x64": "1.9.4"
+				"@biomejs/cli-darwin-arm64": "2.0.0",
+				"@biomejs/cli-darwin-x64": "2.0.0",
+				"@biomejs/cli-linux-arm64": "2.0.0",
+				"@biomejs/cli-linux-arm64-musl": "2.0.0",
+				"@biomejs/cli-linux-x64": "2.0.0",
+				"@biomejs/cli-linux-x64-musl": "2.0.0",
+				"@biomejs/cli-win32-arm64": "2.0.0",
+				"@biomejs/cli-win32-x64": "2.0.0"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
-			"integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.0.0.tgz",
+			"integrity": "sha512-QvqWYtFFhhxdf8jMAdJzXW+Frc7X8XsnHQLY+TBM1fnT1TfeV/v9vsFI5L2J7GH6qN1+QEEJ19jHibCY2Ypplw==",
 			"cpu": [
 				"arm64"
 			],
@@ -177,9 +176,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
-			"integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.0.0.tgz",
+			"integrity": "sha512-5JFhls1EfmuIH4QGFPlNpxJQFC6ic3X1ltcoLN+eSRRIPr6H/lUS1ttuD0Fj7rPgPhZqopK/jfH8UVj/1hIsQw==",
 			"cpu": [
 				"x64"
 			],
@@ -194,9 +193,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
-			"integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.0.0.tgz",
+			"integrity": "sha512-BAH4QVi06TzAbVchXdJPsL0Z/P87jOfes15rI+p3EX9/EGTfIjaQ9lBVlHunxcmoptaA5y1Hdb9UYojIhmnjIw==",
 			"cpu": [
 				"arm64"
 			],
@@ -211,9 +210,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
-			"integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.0.0.tgz",
+			"integrity": "sha512-Bxsz8ki8+b3PytMnS5SgrGV+mbAWwIxI3ydChb/d1rURlJTMdxTTq5LTebUnlsUWAX6OvJuFeiVq9Gjn1YbCyA==",
 			"cpu": [
 				"arm64"
 			],
@@ -228,9 +227,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
-			"integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.0.0.tgz",
+			"integrity": "sha512-09PcOGYTtkopWRm6mZ/B6Mr6UHdkniUgIG/jLBv+2J8Z61ezRE+xQmpi3yNgUrFIAU4lPA9atg7mhvE/5Bo7Wg==",
 			"cpu": [
 				"x64"
 			],
@@ -245,9 +244,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
-			"integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.0.0.tgz",
+			"integrity": "sha512-tiQ0ABxMJb9I6GlfNp0ulrTiQSFacJRJO8245FFwE3ty3bfsfxlU/miblzDIi+qNrgGsLq5wIZcVYGp4c+HXZA==",
 			"cpu": [
 				"x64"
 			],
@@ -262,9 +261,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
-			"integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.0.0.tgz",
+			"integrity": "sha512-vrTtuGu91xNTEQ5ZcMJBZuDlqr32DWU1r14UfePIGndF//s2WUAmer4FmgoPgruo76rprk37e8S2A2c0psXdxw==",
 			"cpu": [
 				"arm64"
 			],
@@ -279,9 +278,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
-			"integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.0.0.tgz",
+			"integrity": "sha512-2USVQ0hklNsph/KIR72ZdeptyXNnQ3JdzPn3NbjI4Sna34CnxeiYAaZcZzXPDl5PYNFBivV4xmvT3Z3rTmyDBg==",
 			"cpu": [
 				"x64"
 			],

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"test": "vitest"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.0.0",
+		"@biomejs/biome": "2.0.4",
 		"@types/jest": "^29.5.8",
 		"@types/node": "^18.7.3",
 		"npm-run-all": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"test": "vitest"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "1.9.4",
+		"@biomejs/biome": "2.0.0",
 		"@types/jest": "^29.5.8",
 		"@types/node": "^18.7.3",
 		"npm-run-all": "^4.1.5",

--- a/src/comparator/NodeComparator.ts
+++ b/src/comparator/NodeComparator.ts
@@ -1,5 +1,4 @@
 import type { Json } from "../types/json";
-import type { Node } from "../types/node";
 import { Nothing } from "../types/nothing";
 import type { ComparisonOperators } from "./ComparisonOperators";
 

--- a/src/functions/count.ts
+++ b/src/functions/count.ts
@@ -1,7 +1,7 @@
 import {
+	createFunctionDefinition,
 	NodesTypeDef,
 	ValueTypeDef,
-	createFunctionDefinition,
 } from "./function_definitions";
 
 // 2.4.5. count() Function Extension

--- a/src/functions/function_definitions.ts
+++ b/src/functions/function_definitions.ts
@@ -1,6 +1,6 @@
 import { FunctionType } from "../functions/function_types";
 import type { Json, JsonValue } from "../types/json";
-import { type Node, type NodeList, isNode, isNodeList } from "../types/node";
+import { isNode, isNodeList, type Node, type NodeList } from "../types/node";
 import { Nothing } from "../types/nothing";
 import { isJsonPrimitive } from "../utils";
 

--- a/src/functions/length.ts
+++ b/src/functions/length.ts
@@ -1,6 +1,6 @@
 import { Nothing } from "../types/nothing";
 import { isJsonObject } from "../utils";
-import { ValueTypeDef, createFunctionDefinition } from "./function_definitions";
+import { createFunctionDefinition, ValueTypeDef } from "./function_definitions";
 import type { FunctionType } from "./function_types";
 
 // 2.4.4. length() Function Extension

--- a/src/functions/match.ts
+++ b/src/functions/match.ts
@@ -1,10 +1,10 @@
 import { convertIRegexpToJsRegexp } from "../utils/convertIRegexpToJsRegexp";
 import {
+	createFunctionDefinition,
 	LogicalTypeDef,
 	ValueTypeDef,
-	createFunctionDefinition,
 } from "./function_definitions";
-import { FunctionType, convertLogicalType } from "./function_types";
+import { convertLogicalType, FunctionType } from "./function_types";
 
 // 2.4.6. match() Function Extension
 // Parameters:

--- a/src/functions/search.ts
+++ b/src/functions/search.ts
@@ -1,10 +1,10 @@
 import { convertIRegexpToJsRegexp } from "../utils/convertIRegexpToJsRegexp";
 import {
+	createFunctionDefinition,
 	LogicalTypeDef,
 	ValueTypeDef,
-	createFunctionDefinition,
 } from "./function_definitions";
-import { FunctionType, convertLogicalType } from "./function_types";
+import { convertLogicalType, FunctionType } from "./function_types";
 
 // 2.4.7. search() Function Extension
 // Parameters:

--- a/src/functions/value.ts
+++ b/src/functions/value.ts
@@ -1,8 +1,8 @@
 import { Nothing } from "../types/nothing";
 import {
+	createFunctionDefinition,
 	NodesTypeDef,
 	ValueTypeDef,
-	createFunctionDefinition,
 } from "./function_definitions";
 
 // 2.4.8. value() Function Extension

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,7 +1,7 @@
 import type { JsonpathQuery } from "./grammar/ast";
 import { applyRoot } from "./parsers/root";
 import type { Json } from "./types/json";
-import { type Node, type NodeList, createNode } from "./types/node";
+import { createNode, type Node, type NodeList } from "./types/node";
 
 export function run(json: Json, query: JsonpathQuery): NodeList {
 	const rootNode: Node = createNode(json, "$");

--- a/src/parsers/array_slice_selector.ts
+++ b/src/parsers/array_slice_selector.ts
@@ -1,5 +1,5 @@
 import type { SliceSelector } from "../grammar/ast";
-import { type Node, type NodeList, addIndexPath } from "../types/node";
+import { addIndexPath, type Node, type NodeList } from "../types/node";
 
 // 2.3.4. Array Slice Selector
 // The array slice selector has the form <start>:<end>:<step>.

--- a/src/parsers/filter_selector.ts
+++ b/src/parsers/filter_selector.ts
@@ -24,7 +24,7 @@ import type {
 import type { JsonValue } from "../types/json.d";
 import type { Node, NodeList } from "../types/node";
 import { Nothing } from "../types/nothing";
-import { isJsonArray, isJsonObject, isJsonPrimitive, toArray } from "../utils";
+import { isJsonArray, isJsonObject, isJsonPrimitive } from "../utils";
 import { enumerateNode } from "../utils/enumerateNode";
 import { applyFunction } from "./function_extentions";
 import { applyRoot, applySegments } from "./root";

--- a/src/parsers/root.ts
+++ b/src/parsers/root.ts
@@ -10,10 +10,10 @@ import type {
 	WildcardSelector,
 } from "../grammar/ast";
 import {
-	type Node,
-	type NodeList,
 	addIndexPath,
 	addMemberPath,
+	type Node,
+	type NodeList,
 } from "../types/node";
 import { isJsonObject } from "../utils";
 import { traverseDescendant } from "../utils/traverseDescendant";
@@ -102,7 +102,7 @@ function applySelector(
 // 2.3.2. Wildcard Selector
 // A wildcard selector selects the nodes of all children of an object or array.
 function applyWildcardSelector(
-	selector: WildcardSelector,
+	_selector: WildcardSelector,
 	node: Node,
 ): NodeList {
 	const results: NodeList = [];
@@ -110,7 +110,7 @@ function applyWildcardSelector(
 
 	if (Array.isArray(json)) {
 		for (const a in json) {
-			if (Object.prototype.hasOwnProperty.call(node.value, a)) {
+			if (Object.hasOwn(node.value, a)) {
 				// Note that the children of an object are its member values, not its member names.
 				// results.push({ json: json[a], path: `${node.path}[${a}]` });
 				results.push(addIndexPath(node, json[a], Number(a)));
@@ -118,7 +118,7 @@ function applyWildcardSelector(
 		}
 	} else if (isJsonObject(json)) {
 		for (const a in json) {
-			if (Object.prototype.hasOwnProperty.call(json, a)) {
+			if (Object.hasOwn(json, a)) {
 				results.push(addMemberPath(node, json[a], a));
 			}
 		}

--- a/src/utils/enumerateNode.ts
+++ b/src/utils/enumerateNode.ts
@@ -1,13 +1,13 @@
 import {
-	type Node,
-	type NodeList,
 	addIndexPath,
 	addMemberPath,
+	type Node,
+	type NodeList,
 } from "../types/node";
 import { isJsonArray, isJsonObject, isJsonPrimitive } from "../utils";
 
 export function enumerateNode(node: Node): NodeList {
-	const { value: json, path } = node;
+	const { value: json } = node;
 	if (isJsonPrimitive(json)) {
 		return [];
 	}

--- a/tests/RFC9535/jsonpath-compliance-test-suite.test.ts
+++ b/tests/RFC9535/jsonpath-compliance-test-suite.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, test } from "vitest";
-import { testJSONPath, testNormalizedPath } from "../utils";
-
 import { JSONPathJS } from "../../src/jsonpath_js";
 import type { JsonValue } from "../../src/types/json";
+import { testJSONPath, testNormalizedPath } from "../utils";
 import cts from "./jsonpath-compliance-test-suite/cts.json";
 
 // https://github.com/jsonpath-standard/jsonpath-compliance-test-suite


### PR DESCRIPTION
## Summary
- Upgrade @biomejs/biome from v1.9.4 to v2.0.0
- Migrate configuration using automated migration tool
- Apply lint fixes for new v2 rules and style guidelines

## Changes Made
- **Package update**: Updated `@biomejs/biome` to `2.0.0` in package.json
- **Configuration migration**: Used `biome migrate --write` for automatic config updates
- **Config structure changes**:
  - Updated schema to v2.0.0
  - Converted `ignore` patterns to `includes` with negation (`\!**/`)
  - Moved `organizeImports` to `assist.actions.source.organizeImports`
  - Added new default style rules from v2
- **Code fixes**: Applied automatic fixes for:
  - Import organization and sorting
  - Unused imports and variables removal
  - Object.hasOwn() usage instead of Object.prototype.hasOwnProperty
  - Function parameter prefixing for unused params

## Test Plan
- [x] Install updated dependency
- [x] Run migration tool successfully  
- [x] Apply all lint fixes
- [x] Verify `npm run lint` passes without errors
- [x] Ensure all TypeScript compilation works
- [x] Confirm existing functionality unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)