### PR TITLE
Add Lefthook for automated Git hooks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,7 @@
+pre-commit:
+  commands:
+    lint:
+      run: npm run lint
+      stage_fixed: true
+    test:
+      run: npm test -- --watch=false

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@biomejs/biome": "2.0.4",
 				"@types/jest": "^29.5.8",
 				"@types/node": "^18.7.3",
+				"lefthook": "^1.11.14",
 				"npm-run-all": "^4.1.5",
 				"peggy": "^5.0.4",
 				"tsup": "^8.3.5",
@@ -3029,6 +3030,169 @@
 			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/lefthook": {
+			"version": "1.11.14",
+			"resolved": "https://registry.npmjs.org/lefthook/-/lefthook-1.11.14.tgz",
+			"integrity": "sha512-Dv91Lnu/0jLT5pCZE0IkEfrpTXUhyX9WG4upEMPkKPCl5aBgJdoqVw/hbh8drcVrC6y7k1PqsRmWSERmO57weQ==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"lefthook": "bin/index.js"
+			},
+			"optionalDependencies": {
+				"lefthook-darwin-arm64": "1.11.14",
+				"lefthook-darwin-x64": "1.11.14",
+				"lefthook-freebsd-arm64": "1.11.14",
+				"lefthook-freebsd-x64": "1.11.14",
+				"lefthook-linux-arm64": "1.11.14",
+				"lefthook-linux-x64": "1.11.14",
+				"lefthook-openbsd-arm64": "1.11.14",
+				"lefthook-openbsd-x64": "1.11.14",
+				"lefthook-windows-arm64": "1.11.14",
+				"lefthook-windows-x64": "1.11.14"
+			}
+		},
+		"node_modules/lefthook-darwin-arm64": {
+			"version": "1.11.14",
+			"resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-1.11.14.tgz",
+			"integrity": "sha512-YPbUK6kGytY5W6aNUrzK7Vod3ynLVvj5JQiBh0DjlxCHMgIQPpFkDfwQzGw1E8CySyC95HXO83En5Ule8umS7g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/lefthook-darwin-x64": {
+			"version": "1.11.14",
+			"resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-1.11.14.tgz",
+			"integrity": "sha512-l9RhSBp1SHqLCjSGWoeeVWqKcTBOMW8v2CCYrUt5eb6sik7AjT6+Neqf3sClsXH7SjELjj43yjmg6loqPtfDgg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/lefthook-freebsd-arm64": {
+			"version": "1.11.14",
+			"resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-1.11.14.tgz",
+			"integrity": "sha512-oSdJKGGMohktFXC6faZCUt5afyHpDwWGIWAkHGgOXUVD/LiZDEn6U/8cQmKm1UAfBySuPTtfir0VeM04y6188g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/lefthook-freebsd-x64": {
+			"version": "1.11.14",
+			"resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-1.11.14.tgz",
+			"integrity": "sha512-gZdMWZwOtIhIPK3GPYac7JhXrxF188gkw65i6O7CedS/meDlK2vjBv5BUVLeD/satv4+jibEdV0h4Qqu/xIh2A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/lefthook-linux-arm64": {
+			"version": "1.11.14",
+			"resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-1.11.14.tgz",
+			"integrity": "sha512-sZmqbTsGQFQw7gbfi9eIHFOxfcs66QfZYLRMh1DktODhyhRXB8RtI6KMeKCtPEGLhbK55/I4TprC8Qvj86UBgw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/lefthook-linux-x64": {
+			"version": "1.11.14",
+			"resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-1.11.14.tgz",
+			"integrity": "sha512-c+to1BRzFe419SNXAR6YpCBP8EVWxvUxlON3Z+efzmrHhdlhm7LvEoJcN4RQE4Gc2rJQJNe87OjsEZQkc4uQLg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/lefthook-openbsd-arm64": {
+			"version": "1.11.14",
+			"resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-1.11.14.tgz",
+			"integrity": "sha512-fivG3D9G4ASRCTf3ecfz1WdnrHCW9pezaI8v1NVve8t6B2q0d0yeaje5dfhoAsAvwiFPRaMzka1Qaoyu8O8G9Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			]
+		},
+		"node_modules/lefthook-openbsd-x64": {
+			"version": "1.11.14",
+			"resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-1.11.14.tgz",
+			"integrity": "sha512-vikmG0jf7JVKR3be6Wk3l1jtEdedEqk1BTdsaHFX1bj0qk0azcqlZ819Wt/IoyIYDzQCHKowZ6DuXsRjT+RXWA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			]
+		},
+		"node_modules/lefthook-windows-arm64": {
+			"version": "1.11.14",
+			"resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-1.11.14.tgz",
+			"integrity": "sha512-5PoAJ9QKaqxJn1NWrhrhXpAROpl/dT7bGTo7VMj2ATO1cpRatbn6p+ssvc3tgeriFThowFb1D11Fg6OlFLi6UQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/lefthook-windows-x64": {
+			"version": "1.11.14",
+			"resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-1.11.14.tgz",
+			"integrity": "sha512-kBeOPR0Aj5hQGxoBBntgz5/e/xaH5Vnzlq9lJjHW8sf23qu/JVUGg6ceCoicyVWJi+ZOBliTa8KzwCu+mgyJjw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
 		},
 		"node_modules/lilconfig": {
 			"version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"@biomejs/biome": "2.0.4",
 		"@types/jest": "^29.5.8",
 		"@types/node": "^18.7.3",
+		"lefthook": "^1.11.14",
 		"npm-run-all": "^4.1.5",
 		"peggy": "^5.0.4",
 		"tsup": "^8.3.5",


### PR DESCRIPTION
## Summary
• Added Lefthook configuration for automated pre-commit hooks
• Integrated linting and testing into the commit workflow
• Added Lefthook as a dev dependency to ensure consistent hook execution

## Test plan
- [x] Verify Lefthook configuration syntax
- [x] Test that pre-commit hooks run linting with `npm run lint`
- [x] Test that pre-commit hooks run tests with `npm test --watch=false`
- [x] Confirm that `stage_fixed` option works for auto-fixing lint issues

🤖 Generated with [Claude Code](https://claude.ai/code)